### PR TITLE
Padronizar botões genéricos e cores do sistema

### DIFF
--- a/templates/agedar.html
+++ b/templates/agedar.html
@@ -94,7 +94,7 @@
                             <i class="fas fa-arrow-left me-1"></i>Voltar
                         </a>
                         <button type="submit" class="btn btn-primary">
-                            <i class="fas fa-save me-1"></i>Agendar
+                            <i class="fas fa-save me-1"></i>Inserir
                         </button>
                     </div>
                 </form>

--- a/templates/bot_whatsapp.html
+++ b/templates/bot_whatsapp.html
@@ -56,7 +56,7 @@
                     </div>
                     
                     <div class="d-flex justify-content-between">
-                        <button type="button" class="btn btn-outline-info" onclick="testConnection()">
+                        <button type="button" class="btn btn-outline-primary" onclick="testConnection()">
                             <i class="fas fa-plug me-1"></i>Testar Conexão
                         </button>
                         <button type="submit" class="btn btn-primary">

--- a/templates/cadastro.html
+++ b/templates/cadastro.html
@@ -35,7 +35,7 @@
                                 <i class="fas fa-user fa-3x mb-3 text-success"></i>
                                 <h5>Cadastrar Cliente</h5>
                                 <p class="text-muted">Cadastrar novo cliente</p>
-                                <a href="{{ url_for('clientes_pesquisar', search=1) }}" class="btn btn-success">
+                                <a href="{{ url_for('clientes_pesquisar', search=1) }}" class="btn btn-primary">
                                     <i class="fas fa-plus me-1"></i>Cadastrar
                                 </a>
                             </div>
@@ -50,7 +50,7 @@
                                 <i class="fas fa-users fa-3x mb-3 text-info"></i>
                                 <h5>Cadastrar Funcionário</h5>
                                 <p class="text-muted">Cadastrar novo funcionário</p>
-                                <a href="{{ url_for('funcionarios_pesquisar', search=1) }}" class="btn btn-info">
+                                <a href="{{ url_for('funcionarios_pesquisar', search=1) }}" class="btn btn-primary">
                                     <i class="fas fa-plus me-1"></i>Gerenciar
                                 </a>
                             </div>
@@ -65,7 +65,7 @@
                                 <i class="fas fa-briefcase fa-3x mb-3 text-warning"></i>
                                 <h5>Cadastrar Cargo</h5>
                                 <p class="text-muted">Cadastrar novo cargo</p>
-                                <a href="{{ url_for('cargos_main') }}" class="btn btn-warning">
+                                <a href="{{ url_for('cargos_main') }}" class="btn btn-primary">
                                     <i class="fas fa-plus me-1"></i>Gerenciar
                                 </a>
                             </div>

--- a/templates/cargos.html
+++ b/templates/cargos.html
@@ -8,7 +8,7 @@
             <p class="text-muted m-0">Gerenciar cargos de funcionários</p>
         </div>
         <a href="#" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#createCargoModal">
-            <i class="fas fa-plus me-1"></i>Novo Cargo
+            <i class="fas fa-plus me-1"></i>Inserir
         </a>
     </div>
 </div>
@@ -20,7 +20,7 @@
             <input type="text" name="query" class="form-control" placeholder="Ex.: Gerente" value="{{ query }}">
         </div>
         <div class="col-12 col-md-2">
-            <button class="btn btn-success w-100" type="submit">Aplicar</button>
+            <button class="btn btn-primary w-100" type="submit">Aplicar</button>
         </div>
     </div>
 </form>
@@ -125,7 +125,7 @@
                 </div>
                 <div class="modal-footer">
                     <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
-                    <button type="submit" class="btn btn-primary">Salvar Cargo</button>
+                    <button type="submit" class="btn btn-primary">Salvar</button>
                 </div>
             </form>
         </div>

--- a/templates/cliente_inserir.html
+++ b/templates/cliente_inserir.html
@@ -71,8 +71,8 @@
                         <a href="{{ url_for('clientes_pesquisar', search=1) }}" class="btn btn-outline-secondary btn-lg">
                             <i class="fas fa-times me-2"></i>Cancelar
                         </a>
-                        <button type="submit" class="btn btn-success btn-lg px-4">
-                            <i class="fas fa-save me-2"></i>Salvar cliente
+                        <button type="submit" class="btn btn-primary btn-lg px-4">
+                            <i class="fas fa-save me-2"></i>Salvar
                         </button>
                     </div>
                 </form>

--- a/templates/clientes_pesquisa.html
+++ b/templates/clientes_pesquisa.html
@@ -8,7 +8,7 @@
             <p class="text-muted m-0">Pesquisar e gerenciar clientes</p>
         </div>
         <a href="{{ url_for('clientes_inserir') }}" class="btn btn-primary">
-            <i class="fas fa-plus me-1"></i>Novo cliente
+            <i class="fas fa-plus me-1"></i>Inserir
         </a>
     </div>
  </div>
@@ -29,7 +29,7 @@
             </select>
         </div>
         <div class="col-12 col-md-2">
-            <button type="submit" class="btn btn-success w-100">Aplicar</button>
+            <button type="submit" class="btn btn-primary w-100">Aplicar</button>
         </div>
     </div>
 </form>

--- a/templates/funcionario_inserir.html
+++ b/templates/funcionario_inserir.html
@@ -65,8 +65,8 @@
                         <a href="{{ url_for('funcionarios_pesquisar', search=1) }}" class="btn btn-outline-secondary btn-lg">
                             <i class="fas fa-times me-2"></i>Cancelar
                         </a>
-                        <button type="submit" class="btn btn-info btn-lg px-4">
-                            <i class="fas fa-save me-2"></i>Criar funcionário
+                        <button type="submit" class="btn btn-primary btn-lg px-4">
+                            <i class="fas fa-save me-2"></i>Inserir
                         </button>
                     </div>
                 </form>

--- a/templates/funcionarios.html
+++ b/templates/funcionarios.html
@@ -8,7 +8,7 @@
             <p class="text-muted">Gerenciar funcionários do sistema</p>
         </div>
         <a href="#" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#createEmployeeModal">
-            <i class="fas fa-plus me-1"></i>Novo Funcionário
+            <i class="fas fa-plus me-1"></i>Inserir
         </a>
     </div>
 </div>
@@ -110,7 +110,7 @@
                 <div class="modal-footer">
                     <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancelar</button>
                     {% if form %}
-                        <button type="submit" class="btn btn-primary">Criar Funcionário</button>
+                        <button type="submit" class="btn btn-primary">Inserir</button>
                     {% endif %}
                 </div>
             </form>

--- a/templates/funcionarios_pesquisa.html
+++ b/templates/funcionarios_pesquisa.html
@@ -8,7 +8,7 @@
             <p class="text-muted m-0">Pesquisar e gerenciar funcionários</p>
         </div>
         <a href="{{ url_for('criar_funcionario') }}" class="btn btn-primary">
-            <i class="fas fa-plus me-1"></i>Novo funcionário
+            <i class="fas fa-plus me-1"></i>Inserir
         </a>
     </div>
  </div>
@@ -29,7 +29,7 @@
             </select>
         </div>
         <div class="col-12 col-md-2">
-            <button type="submit" class="btn btn-success w-100">Aplicar</button>
+            <button type="submit" class="btn btn-primary w-100">Aplicar</button>
         </div>
     </div>
 </form>

--- a/templates/index.html
+++ b/templates/index.html
@@ -109,7 +109,7 @@
             </div>
         </div>
         <div class="text-center mt-5">
-            <a href="{{ url_for('login') }}" class="btn btn-success btn-lg px-5">
+            <a href="{{ url_for('login') }}" class="btn btn-primary btn-lg px-5">
                 <i class="fas fa-sign-in-alt me-2"></i>Acessar
             </a>
         </div>

--- a/templates/pesquisar_servico.html
+++ b/templates/pesquisar_servico.html
@@ -9,7 +9,7 @@
         </div>
         <div class="d-flex gap-2">
             <a href="{{ url_for('servicos_inserir') }}" class="btn btn-primary">
-                <i class="fas fa-plus me-1"></i>Novo serviço
+                <i class="fas fa-plus me-1"></i>Inserir
             </a>
         </div>
     </div>
@@ -61,7 +61,7 @@
             </select>
         </div>
         <div class="col-12 col-md-2">
-            <button type="submit" class="btn btn-success w-100">Aplicar</button>
+            <button type="submit" class="btn btn-primary w-100">Aplicar</button>
         </div>
     </div>
 

--- a/templates/relatorios.html
+++ b/templates/relatorios.html
@@ -123,7 +123,7 @@
                     </div>
                     <div class="col-md-3 mb-3">
                         <div class="d-grid">
-                            <button class="btn btn-outline-info">
+                            <button class="btn btn-outline-primary">
                                 <i class="fas fa-print me-2"></i>
                                 Imprimir Relatório
                             </button>
@@ -131,7 +131,7 @@
                     </div>
                     <div class="col-md-3 mb-3">
                         <div class="d-grid">
-                            <button class="btn btn-outline-success">
+                            <button class="btn btn-outline-primary">
                                 <i class="fas fa-calendar me-2"></i>
                                 Relatório Período
                             </button>
@@ -139,7 +139,7 @@
                     </div>
                     <div class="col-md-3 mb-3">
                         <div class="d-grid">
-                            <button class="btn btn-outline-warning">
+                            <button class="btn btn-outline-primary">
                                 <i class="fas fa-chart-line me-2"></i>
                                 Análise Detalhada
                             </button>

--- a/templates/servico_inserir.html
+++ b/templates/servico_inserir.html
@@ -59,8 +59,8 @@
                         <a href="{{ url_for('servicos_pesquisar', search=1) }}" class="btn btn-outline-secondary btn-lg">
                             <i class="fas fa-times me-2"></i>Cancelar
                         </a>
-                        <button type="submit" class="btn btn-warning btn-lg px-4">
-                            <i class="fas fa-save me-2"></i>Salvar serviço
+                        <button type="submit" class="btn btn-primary btn-lg px-4">
+                            <i class="fas fa-save me-2"></i>Salvar
                         </button>
                     </div>
                 </form>

--- a/templates/usuario_inserir.html
+++ b/templates/usuario_inserir.html
@@ -187,7 +187,7 @@
                             <i class="fas fa-times me-2"></i>Cancelar
                         </a>
                         <button type="submit" class="btn btn-primary btn-lg px-4">
-                            <i class="fas fa-save me-2"></i>Salvar usuário
+                            <i class="fas fa-save me-2"></i>Salvar
                         </button>
                     </div>
                 </form>

--- a/templates/usuarios_pesquisa.html
+++ b/templates/usuarios_pesquisa.html
@@ -8,7 +8,7 @@
             <p class="text-muted m-0">Pesquisar e gerenciar usuários do sistema</p>
         </div>
         <a href="{{ url_for('usuario_inserir') }}" class="btn btn-primary">
-            <i class="fas fa-plus me-1"></i>Novo usuário
+            <i class="fas fa-plus me-1"></i>Inserir
         </a>
     </div>
 </div>
@@ -29,7 +29,7 @@
             </select>
         </div>
         <div class="col-12 col-md-2">
-            <button type="submit" class="btn btn-success w-100">Aplicar</button>
+            <button type="submit" class="btn btn-primary w-100">Aplicar</button>
         </div>
     </div>
     {% if query %}


### PR DESCRIPTION
Padroniza rótulos de botões para termos genéricos ('Inserir'/'Salvar') e unifica suas cores para a paleta primária do layout (`btn-primary`/`btn-outline-primary`).

---
<a href="https://cursor.com/background-agent?bcId=bc-970aad2b-6d66-4a8a-9550-78d7de6d87e5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-970aad2b-6d66-4a8a-9550-78d7de6d87e5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

